### PR TITLE
feat(antidote-path): return the path of the bundle

### DIFF
--- a/functions/antidote-path
+++ b/functions/antidote-path
@@ -10,4 +10,6 @@ local bundledir=$(_antidote_bundledir $bundle)
 if [[ ! -d $bundledir ]]; then
   echo >&2 "antidote: error: $bundle does not exist in cloned paths"
   return 1
+else
+  echo "$bundledir"
 fi


### PR DESCRIPTION
@mattmc3 Not sure what the full intent of the `antidote-path` function is, but it seemed intuitive to me that it would return the path to the bundle.  Here is my suggestion to implement this.

P.S. Thanks for starting this project.  So far really enjoying the simplicity it has brought to my zsh environment.