### PR TITLE
Fix #40 - correctly document zstyle

### DIFF
--- a/man/antidote-load.md
+++ b/man/antidote-load.md
@@ -19,12 +19,12 @@ header: Antidote Manual
 The default bundle file is **${ZDOTDIR:-~}/.zsh_plugins.txt**. This can be overridden with the following **zstyle**:
 
 |   bundlefile=~/.zplugins
-|   zstyle -s ':antidote:bundle' file $bundlefile
+|   zstyle ':antidote:bundle' file $bundlefile
 
 The default static file is **${ZDOTDIR:-~}/.zsh_plugins.zsh**. This can be overridden with the following **zstyle**:
 
 |   staticfile=~/.zplugins.zsh
-|   zstyle -s ':antidote:static' file $staticfile
+|   zstyle ':antidote:static' file $staticfile
 
 # OPTIONS
 

--- a/man/man1/antidote-load.1
+++ b/man/man1/antidote-load.1
@@ -34,7 +34,7 @@ This can be overridden with the following \f[B]zstyle\f[R]:
 .PD 0
 .P
 .PD
-\ \ zstyle -s `:antidote:bundle' file $bundlefile
+\ \ zstyle `:antidote:bundle' file $bundlefile
 .PP
 The default static file is \f[B]${ZDOTDIR:-\[ti]}/.zsh_plugins.zsh\f[R].
 This can be overridden with the following \f[B]zstyle\f[R]:
@@ -43,7 +43,7 @@ This can be overridden with the following \f[B]zstyle\f[R]:
 .PD 0
 .P
 .PD
-\ \ zstyle -s `:antidote:static' file $staticfile
+\ \ zstyle `:antidote:static' file $staticfile
 .SH OPTIONS
 .TP
 -h, --help


### PR DESCRIPTION
There was a typo in the documentation on how to set the bundle and static files with `zstyle`. This fixes it by removing the `-s` flag.