### PR TITLE
Feat conditional annotation

### DIFF
--- a/functions/antidote-bundle
+++ b/functions/antidote-bundle
@@ -60,6 +60,14 @@ for bundlestr in $bundles; do
   # typeset -A bundle=( [repo]=foo/bar [kind]=fpath )
   typeset -A bundle=( $(__antidote_split $'\t' $bundlestr) )
 
+  # nothing to do for clone-only bundles
+  [[ $bundle[kind] != clone ]] || continue
+
+  # nothing to do if a conditional annotation fails
+  if [[ -v bundle[conditional] ]]; then
+    $bundle[conditional] &>/dev/null || continue
+  fi
+
   # special handling for deferred bundles
   if [[ $bundle[kind] = defer ]] && [[ $#prescript -eq 0 ]]; then
     prescript=(
@@ -68,9 +76,6 @@ for bundlestr in $bundles; do
       "fi"
     )
   fi
-
-  # nothing to do for clone-only bundles
-  [[ $bundle[kind] != clone ]] || continue
 
   bundle[kind]=${bundle[kind]:-zsh}
   script+="$(_antidote_script $bundle[repo] $bundle[kind] $bundle[path])"

--- a/tests/test_bundle.zsh
+++ b/tests/test_bundle.zsh
@@ -195,6 +195,35 @@ source $BASEDIR/antidote.zsh
   @test "bundle annotation path:libdir: '$bundle'" "$expected" = "$actual"
 }
 
+# bundle annotation conditionals
+() {
+  function cond_succeed {
+    return 0
+  }
+  function cond_fail {
+    return 1
+  }
+
+  local actual expected bundle bundledir exitcode
+  bundledir="https-COLON--SLASH--SLASH-github.com-SLASH-foo-SLASH-bar"
+  expected=(
+    "fpath+=( $ANTIDOTE_HOME/$bundledir )"
+    "source $ANTIDOTE_HOME/$bundledir/bar.plugin.zsh"
+  )
+
+  bundle="foo/bar conditional:cond_succeed"
+  actual=("${(@f)$(antidote bundle $bundle)}")
+  @test "bundle annotation conditional:success" "$expected" = "$actual"
+
+  bundle="foo/bar conditional:cond_fail"
+  actual=("${(@f)$(antidote bundle $bundle)}")
+  @test "bundle annotation conditional:cond_fail" -z "$actual"
+
+  bundle="foo/bar conditional:missing"
+  actual=("${(@f)$(antidote bundle $bundle)}")
+  @test "bundle annotation conditional:missing" -z "$actual"
+}
+
 # bundle zsh-theme
 () {
   local actual expected bundle bundledir


### PR DESCRIPTION
Fix: #46

You can now define a function like so:

```zsh
function is_macos {
  [[ $OSTYPE == darwin* ]] || return 1
}
```

And then conditionally include a plugin:

```
sorin-ionescu/prezto path:modules/osx conditional:is_macos
```