### PR TITLE
Fix wrong Windows plugin path

### DIFF
--- a/functions/antidote-home
+++ b/functions/antidote-home
@@ -1,5 +1,16 @@
 #!/bin/zsh
 
+# Translate Windows raw paths to more "POSIX" like Paths
+function __fix_windows_path {
+  local path=$1
+  path=${path//\\//}
+  path="/${(L)path}"
+  path=${path//:/}
+  path=${path// /%20}
+  path=${path//\%/%%}
+  echo $path
+}
+
 ### Print where antidote is cloning bundles.
 #
 # usage: antidote home [-h|--help]
@@ -24,7 +35,8 @@ function antidote-home {
   elif [[ "${OSTYPE}" == darwin* ]]; then
     result="$HOME/Library/Caches/antidote"
   elif [[ "${OSTYPE}" == (cygwin|msys)* ]]; then
-    result="$LOCALAPPDATA/antidote"
+    posix_string=$(__fix_windows_path $LOCALAPPDATA)
+    result="$posix_string/antidote"
   elif [[ -n "$XDG_CACHE_HOME" ]]; then
     result="$XDG_CACHE_HOME/antidote"
   else


### PR DESCRIPTION
Closes #121 

This basically works by "translating" the string returned by `$LOCALAPPDATA` to a more POSIX-like string.

I have tested it locally on my machine and here is my ZSH setup running without issues (aside from fonts)

![Screenshot 2023-05-14 210549](https://github.com/mattmc3/antidote/assets/38844659/8451d4dd-83c4-42e7-b608-71d1d84d4d13)
![image](https://github.com/mattmc3/antidote/assets/38844659/d7fbf892-4cd0-454d-9ae1-d787d86e6fac)
