### PR TITLE
Fix typos present in manpage sources.

### DIFF
--- a/man/antidote-bundle.md
+++ b/man/antidote-bundle.md
@@ -14,7 +14,7 @@ header: Antidote Manual
 
 # DESCRIPTION
 
-**antidote-bundle** assembles your Zsh plugins. Bundles can be git repos, or local files or dirctories. If a plugin is a repo, it will be cloned if necessary. The zsh code necessary to load (source) the plugin is then printed.
+**antidote-bundle** assembles your Zsh plugins. Bundles can be git repos, or local files or directories. If a plugin is a repo, it will be cloned if necessary. The zsh code necessary to load (source) the plugin is then printed.
 
 |   antidote bundle gituser/gitrepo
 |   antidote bundle $ZSH_CUSTOM/plugins/myplugin
@@ -40,7 +40,7 @@ Bundles also support annotations. Annotations allow you have finer grained contr
 :   The conditonal annotation allows you to wrap an **if** statement around a plugin's load script. Supply the name of a zero argument zsh function to conditional to perform the test (eg: \'conditional:is-macos\').
 
 `pre` / `post`
-:   The pre and post annotations allow you to call a function befor or after a plugin's load script. This is helpful when configuring plugins, since the configuration functions will only run for active plugins. Supply the name of a zero argument zsh function to pre or post.
+:   The pre and post annotations allow you to call a function before or after a plugin's load script. This is helpful when configuring plugins, since the configuration functions will only run for active plugins. Supply the name of a zero argument zsh function to pre or post.
 
 `autoload`
 :   The autoload annotation allows you to autoload a zsh functions directory in addition to however the plugin was loaded as specified by \'kind\'. Supply a relative path to autoload (eg: \'autoload:functions\').

--- a/man/antidote-init.md
+++ b/man/antidote-init.md
@@ -16,7 +16,7 @@ header: Antidote Manual
 
 **antidote-init** changes how the **antidote** command works by causing **antidote bundle** to automatically source its own output instead of just generating the Zsh script for a static file.
 
-This behavior exists mainly to support legacy antigen/antibody usage. Static bundling is highly recommended for the best performance. However, dynamic bundling may be preferrable for some scenarios, so you can rely on this functionality remaining a key feature in **antidote** to support users preferring dynamic bundles.
+This behavior exists mainly to support legacy antigen/antibody usage. Static bundling is highly recommended for the best performance. However, dynamic bundling may be preferable for some scenarios, so you can rely on this functionality remaining a key feature in **antidote** to support users preferring dynamic bundles.
 
 Typical usage involves adding this snippet to your **.zshrc** before using **antidote bundle** commands:
 

--- a/man/footer.md
+++ b/man/footer.md
@@ -5,7 +5,7 @@ See GitHub Issues: <https://github.com/mattmc3/antidote/issues>
 # AUTHORS
 
 - Copyright (c) 2021-2023 Matt McElheny
-- antidote contributers: <https://github.com/mattmc3/antidote/graphs/contributors>
+- antidote contributors: <https://github.com/mattmc3/antidote/graphs/contributors>
 
 # LICENSE
 


### PR DESCRIPTION
They were spotted by the `lintian` tool while packaging for Debian and were fixed in a package-level patch but I think it's better to fix them upstream.