### PR TITLE
Fix bundle submodules not updating

### DIFF
--- a/functions/antidote-update
+++ b/functions/antidote-update
@@ -51,7 +51,7 @@
       () {
         local oldsha=$(git -C "$1" rev-parse --short HEAD)
         git -C "$1" pull --quiet --ff --rebase --autostash
-        git -C "$1" submodule update --init --recursive --depth 1
+        git -C "$1" submodule --quiet update --init --recursive --depth 1
         local newsha=$(git -C "$1" rev-parse --short HEAD)
         if [[ $oldsha != $newsha ]]; then
           print "${green}antidote: updated: $2 ${oldsha} -> ${newsha}${normal}"

--- a/functions/antidote-update
+++ b/functions/antidote-update
@@ -51,6 +51,7 @@
       () {
         local oldsha=$(git -C "$1" rev-parse --short HEAD)
         git -C "$1" pull --quiet --ff --rebase --autostash
+        git -C "$1" submodule update --init --recursive --depth 1
         local newsha=$(git -C "$1" rev-parse --short HEAD)
         if [[ $oldsha != $newsha ]]; then
           print "${green}antidote: updated: $2 ${oldsha} -> ${newsha}${normal}"

--- a/tests/functions/mockgit
+++ b/tests/functions/mockgit
@@ -13,6 +13,7 @@
   local args=("$@[@]")
   local o_path o_quiet o_ff o_rebase o_autostash o_short
   local o_depth o_recurse_submodules o_shallow_submodules o_branch
+  local o_init o_recursive
   zparseopts -D -E --      \
     C:=o_path              \
     -short=o_short         \
@@ -23,7 +24,9 @@
     -recurse-submodules=o_recurse_submodules \
     -shallow-submodules=o_shallow_submodules \
     -depth:=o_depth                          \
-    -branch:=o_branch                        ||
+    -branch:=o_branch                        \
+    -init:=o_init                            \
+    -recursive:=o_recursive                  ||
     return 1
 
   if [[ "$@" = "--version" ]]; then
@@ -56,6 +59,8 @@
   elif [[ "$@" = "rev-parse HEAD" ]]; then
     #echo "a123456"
     echo ""
+  elif [[ "$@" = "submodule update" ]]; then
+    # nothing to do
   else
     echo >&2 "mocking not implemented for git command: git $@"
     return 1


### PR DESCRIPTION
# Overview

Antidote doesn't update or clone the new submodules when running `antidote update`. It only does when calling the first `antidote install`.

# How to reproduce

```shell
antidote install -b v5.8.3 olets/zsh-abbr

pushd "$(antidote path olets/zsh-abbr)"
git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
git fetch origin main
git checkout -b main 
git branch --set-upstream-to=origin/main
popd

echo "olets/zsh-abbr branch:v6.0.0" > ~/.zsh_plugins.txt
antidote update
```

Then:

```
❯ antidote load ~/.zsh_plugins.txt
abbr: Finishing installing dependencies
abbr: There was a problem finishing installing dependencies
```

Same reproduction instructions as above but this time with my fix and now the output looks good:

```
❯ antidote load ~/.zsh_plugins.txt

```