### PR TITLE
Sync changed submodule remotes before pulling them

### DIFF
--- a/functions/antidote-update
+++ b/functions/antidote-update
@@ -51,6 +51,7 @@
       () {
         local oldsha=$(git -C "$1" rev-parse --short HEAD)
         git -C "$1" pull --quiet --ff --rebase --autostash
+        git -C "$1" submodule --quiet sync --recursive
         git -C "$1" submodule --quiet update --init --recursive --depth 1
         local newsha=$(git -C "$1" rev-parse --short HEAD)
         if [[ $oldsha != $newsha ]]; then

--- a/tests/functions/mockgit
+++ b/tests/functions/mockgit
@@ -26,7 +26,7 @@
     -depth:=o_depth                          \
     -branch:=o_branch                        \
     -init:=o_init                            \
-    -recursive:=o_recursive                  ||
+    -recursive=o_recursive                  ||
     return 1
 
   if [[ "$@" = "--version" ]]; then
@@ -59,6 +59,8 @@
   elif [[ "$@" = "rev-parse HEAD" ]]; then
     #echo "a123456"
     echo ""
+  elif [[ "$@" = "submodule sync" ]]; then
+    # nothing to do
   elif [[ "$@" = "submodule update" ]]; then
     # nothing to do
   else


### PR DESCRIPTION
Follow-up of https://github.com/mattmc3/antidote/pull/200

`git submodule update` ignores submodule remote changes from `.gitmodules` for already-initialized submodules. Remotes need to be explicitly synchronized from `.gitmodules` to `.git/config` using the `git submodule sync` command.

Note that removed submodules won't have their folder deleted from the working directory. They will be marked as untracked and the only way I know to get rid of them without custom logic is to run `git clean -ffd` which we might not want as it will also delete any untracked changes that a user might have done.
