### PR TITLE
Make `--init` a boolean option in git mock

### DIFF
--- a/tests/functions/mockgit
+++ b/tests/functions/mockgit
@@ -25,7 +25,7 @@
     -shallow-submodules=o_shallow_submodules \
     -depth:=o_depth                          \
     -branch:=o_branch                        \
-    -init:=o_init                            \
+    -init=o_init                            \
     -recursive=o_recursive                  ||
     return 1
 


### PR DESCRIPTION
I didn't push this in time — sorry! As far as I understand without this change tests will break if `--init` is used as the last option of a git command.
