### PR TITLE
Fix parent directory for antidote:static bundle file is not automatically created

### DIFF
--- a/functions/__antidote_load_prep
+++ b/functions/__antidote_load_prep
@@ -47,6 +47,7 @@
   fi
 
   if [[ ! $staticfile -nt $bundlefile ]] || [[ $force_bundle -eq 1 ]]; then
+    mkdir -p "${staticfile:A:h}"
     antidote bundle <"$bundlefile" >|"$staticfile"
     if [[ -r "${staticfile}.zwc" ]] && ! zstyle -t ':antidote:static' zcompile; then
       __antidote_del -f -- "${staticfile}.zwc"


### PR DESCRIPTION
Fixes #208