### PR TITLE
Change instead of replace bundlefile in purge

### DIFF
--- a/functions/antidote-purge
+++ b/functions/antidote-purge
@@ -75,7 +75,8 @@
     if [[ -e "$bundlefile" ]]; then
       local tmpfile="${bundlefile}.antidote.tmp"
       $__adote_awkcmd -v pat="$bundle" '$0~"^[[:blank:]]*"pat{print "# " $0;next}1' <$bundlefile >|$tmpfile
-      command mv -f "$tmpfile" "$bundlefile" || __antidote_del -f "$tmpfile"
+      command cat "$tmpfile" > "$bundlefile"
+      __antidote_del -f "$tmpfile"
       print "Bundle '$bundle' was commented out in '$bundlefile'."
     fi
   fi


### PR DESCRIPTION
This commit changes the purge command to change the contents of the existing bundlefile instead of replacing the file. The reason for this change is that the bundlefile could be a symlink and this way the symlink is preserved.