### PR TITLE
feat: add CLICOLORS standard support for color detection

### DIFF
--- a/functions/__antidote_supports_color
+++ b/functions/__antidote_supports_color
@@ -1,7 +1,5 @@
 #!/bin/zsh
-[[
-  "$COLORTERM" == truecolor ||
-  "$COLORTERM" == 24bit ||
-  "$TERM" == *256color* ||
-  "$TERM" == *rxvt*
-]]
+[[ -n $NO_COLOR ]] && return 1
+[[ -n $CLICOLOR_FORCE ]] && return 0
+[[ ! -t 1 ]] && return 1
+[[ $COLORTERM == (truecolor|24bit) || $TERM == (*256color*|*rxvt*) ]]

--- a/tests/test_supports_color.md
+++ b/tests/test_supports_color.md
@@ -1,0 +1,54 @@
+# antidote supports color tests
+
+## Setup
+
+```zsh
+% source ./tests/__init__.zsh
+% t_setup
+%
+```
+
+## NO_COLOR takes highest priority
+
+```zsh
+% TERM=xterm-256color CLICOLOR_FORCE=1 NO_COLOR=1 __antidote_supports_color; echo $?
+1
+%
+```
+
+## CLICOLOR_FORCE bypasses TTY check
+
+```zsh
+% TERM=xterm-256color CLICOLOR_FORCE=1 __antidote_supports_color; echo $?
+0
+%
+```
+
+## Non-TTY disables colors
+
+```zsh
+% TERM=xterm-256color __antidote_supports_color; echo $?
+1
+%
+```
+
+## Terminal capability detection
+
+```zsh
+% CLICOLOR_FORCE=1 COLORTERM=truecolor __antidote_supports_color; echo $?
+0
+% CLICOLOR_FORCE=1 COLORTERM=24bit __antidote_supports_color; echo $?
+0
+% CLICOLOR_FORCE=1 TERM=xterm-256color __antidote_supports_color; echo $?
+0
+% CLICOLOR_FORCE=1 TERM=rxvt __antidote_supports_color; echo $?
+0
+%
+```
+
+## Teardown
+
+```zsh
+% t_teardown
+%
+```


### PR DESCRIPTION
## Summary

- Add `NO_COLOR` environment variable support (disables colors when set and non-empty)
- Add `CLICOLOR_FORCE` environment variable support (forces colors even in pipes)
- Add TTY detection (disables colors when stdout is not a terminal)
- Preserve existing `COLORTERM`/`TERM` detection as fallback

Priority order follows the [CLICOLORS standard](https://bixense.com/clicolors/):
`NO_COLOR` > `CLICOLOR_FORCE` > TTY detection > Terminal capability

## Test plan

- [x] `make unittest` passes (621 tests)
- [x] `make test` passes (681 tests)
- [x] Manual verification:
  - `antidote update` shows colors in terminal
  - `NO_COLOR=1 antidote update` shows no colors
  - `antidote update | cat` shows no colors
  - `CLICOLOR_FORCE=1 antidote update | cat` shows colors

Closes #236