### PR TITLE
Redirect git stdout to stderr to prevent output leaks

### DIFF
--- a/functions/antidote-script
+++ b/functions/antidote-script
@@ -87,7 +87,7 @@
   if [[ "$bundle_type" == (repo|url|sshurl) ]] && [[ ! -e "$bundle_path" ]]; then
     local giturl=$(__antidote_tourl $bundle)
     print -ru2 "# antidote cloning $bundle_name..."
-    git clone --quiet --recurse-submodules --shallow-submodules $o_branch $giturl $bundle_path
+    git clone --quiet --recurse-submodules --shallow-submodules $o_branch $giturl $bundle_path >&2
     [[ $? -eq 0 ]] || return 1
   fi
 

--- a/functions/antidote-update
+++ b/functions/antidote-update
@@ -79,14 +79,14 @@
         # Unshallow the repo, because with the SHA locking feature coming in v2, we'll
         # need to have everything.
         if git -C "$1" rev-parse --is-shallow-repository 2>/dev/null | grep -q "true" || [[ -f "$1/.git/shallow" ]]; then
-          git -C "$1" fetch --quiet --unshallow
+          git -C "$1" fetch --quiet --unshallow >&2
         else
-          git -C "$1" fetch --quiet
+          git -C "$1" fetch --quiet >&2
         fi
 
-        git -C "$1" pull --quiet --ff --rebase --autostash
-        git -C "$1" submodule --quiet sync --recursive
-        git -C "$1" submodule --quiet update --init --recursive --depth 1
+        git -C "$1" pull --quiet --ff --rebase --autostash >&2
+        git -C "$1" submodule --quiet sync --recursive >&2
+        git -C "$1" submodule --quiet update --init --recursive --depth 1 >&2
         local newsha=$(git -C "$1" rev-parse --short HEAD)
 
         # Capture all output to temporary file


### PR DESCRIPTION
Added `>&2` as belt-and-suspenders everywhere antidote passes `--quiet` to git.

This isn't strictly a bug in antidote; y'all already pass `--quiet` expecting git to be silent. But unfortunately I have to use a tool https://usegitai.com/ that wraps the git binary on PATH, doesn't respect --quiet, and ends up spewing some stdout on git commands that ends up polluting the antidote-generated ~/.zsh_plugins.zsh.

Example:

```zsh
Fetching git-ai authorship notes, done.
Fetching git-ai authorship notes, done.
Fetching git-ai authorship notes, done.
Fetching git-ai authorship notes, done.
Fetching git-ai authorship notes, done.
fpath+=( "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-zdharma-continuum-SLASH-fast-syntax-highlighting" )
source "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-zdharma-continuum-SLASH-fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
fpath+=( "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-zsh-users-SLASH-zsh-autosuggestions" )
source "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-zsh-users-SLASH-zsh-autosuggestions/zsh-autosuggestions.plugin.zsh"
fpath+=( "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-hlissner-SLASH-zsh-autopair" )
source "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-hlissner-SLASH-zsh-autopair/autopair.plugin.zsh"
source "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-hlissner-SLASH-zsh-autopair/zsh-autopair.plugin.zsh"
fpath+=( "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-jirutka-SLASH-zsh-shift-select" )
source "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-jirutka-SLASH-zsh-shift-select/zsh-shift-select.plugin.zsh"
fpath+=( "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-zpm-zsh-SLASH-clipboard" )
source "$HOME/Library/Caches/antidote/https-COLON--SLASH--SLASH-github.com-SLASH-zpm-zsh-SLASH-clipboard/clipboard.plugin.zsh"
```

Which leads to errors on shell startup like:

```txt
/Users/sargunv/.zsh_plugins.zsh:1: command not found: Fetching
/Users/sargunv/.zsh_plugins.zsh:2: command not found: Fetching
/Users/sargunv/.zsh_plugins.zsh:3: command not found: Fetching
/Users/sargunv/.zsh_plugins.zsh:4: command not found: Fetching
/Users/sargunv/.zsh_plugins.zsh:5: command not found: Fetching
```

Redirecting `>&2` should help such cases.
