### PR TITLE
feat: add commit hash pinning support

### DIFF
--- a/functions/__antidote_bulk_clone
+++ b/functions/__antidote_bulk_clone
@@ -29,6 +29,9 @@
     # find branch annotation if it exists
     match($0, /branch:[^\t ]+/) { opts=opts " --branch " substr($0, RSTART+7, RLENGTH-7) }
 
+    # find commit annotation if it exists
+    match($0, /commit:[^\t ]+/) { opts=opts " --commit " substr($0, RSTART+7, RLENGTH-7) }
+
     # print result
     bundle!=""{ print "antidote-script", opts, bundle, "&" }
 

--- a/functions/antidote-script
+++ b/functions/antidote-script
@@ -4,11 +4,13 @@
 #
 # usage: antidote script [-h|--help] [-k|--kind <kind>] [-p|--path <path>]
 #                        [-c|--conditional <func>] [-b|--branch <branch>]
+#                        [--commit <hash>]
 #                        [--pre <func>] [--post <func>] [--skip-load-defer]
 #                        [-a|--autoload <path>] <bundle>
 # <kind>   : zsh,path,fpath,defer,clone,autoload
 # <path>   : Relative path from the bundle root
 # <branch> : The git branch
+# <commit> : Pin bundle to an exact commit hash
 # <bundle> : A bundle can be a directory, a zsh script, or a git repo
 #
 
@@ -18,11 +20,12 @@
   local MATCH MBEGIN MEND; local -a match mbegin mend  # appease 'warn_create_global'
   local REPLY=
 
-  local -a o_help o_kind o_path o_branch o_cond o_autoload o_pre o_post o_fpath_rule o_skip_load_defer
+  local -a o_help o_kind o_path o_branch o_commit o_cond o_autoload o_pre o_post o_fpath_rule o_skip_load_defer
   zparseopts $_adote_zparopt_flags -- \
     h=o_help       -help=h            \
     a:=o_autoload  -autoload:=a       \
     b:=o_branch    -branch:=b         \
+                   -commit:=o_commit  \
     k:=o_kind      -kind:=k           \
     p:=o_path      -path:=p           \
                    -pre:=o_pre        \
@@ -45,6 +48,7 @@
   [[ $o_path[-1] =~ $re ]] && o_path[-1]=$match
   [[ $o_cond[-1] =~ $re ]] && o_cond[-1]=$match
   [[ $o_branch[-1] =~ $re ]] && o_branch[-1]=$match
+  [[ $o_commit[-1] =~ $re ]] && o_commit[-1]=$match
   [[ $o_pre[-1] =~ $re ]] && o_pre[-1]=$match
   [[ $o_post[-1] =~ $re ]] && o_post[-1]=$match
   [[ $o_fpath_rule[-1] =~ $re ]] && o_fpath_rule[-1]=$match
@@ -89,6 +93,17 @@
     print -ru2 "# antidote cloning $bundle_name..."
     git clone --quiet --recurse-submodules --shallow-submodules $o_branch $giturl $bundle_path >&2
     [[ $? -eq 0 ]] || return 1
+  fi
+
+  # Pin repo bundles to a specific commit when requested.
+  if [[ "$bundle_type" == (repo|url|sshurl) ]] && (( $#o_commit )); then
+    local current_commit desired_commit
+    desired_commit="$o_commit[-1]"
+    current_commit="$(git -C "$bundle_path" rev-parse HEAD 2>/dev/null)"
+    if [[ "$current_commit" != "$desired_commit" ]]; then
+      git -C "$bundle_path" fetch --quiet --tags >&2 || return 1
+      git -C "$bundle_path" checkout --quiet --detach "$desired_commit" >&2 || return 1
+    fi
   fi
 
   # if we only needed to clone the bundle, compile and we're done

--- a/man/antidote-bundle.adoc
+++ b/man/antidote-bundle.adoc
@@ -29,6 +29,8 @@ Bundles also support annotations. Annotations allow you have finer grained contr
   * *autoload*: Autoload all the files in the plugin directory as zsh functions.
 `branch`::
   The branch annotation allows you to change the default branch of a plugin's repo from *main* to a branch of your choosing.
+`commit`::
+  The commit annotation pins a plugin repo to a specific commit hash (eg: `commit:abcd1234`).
 `path`::
   The path annotation allows you to use a subdirectory or file within a plugin's structure instead of the root plugin (eg: `path:plugins/subplugin`).
 `conditional`::
@@ -87,6 +89,13 @@ Using the *branch:* annotation:
 ----
 # don't use the main branch, use develop instead
 antidote bundle zsh-users/zsh-autosuggestions branch:develop
+----
+
+Using the *commit:* annotation:
+
+----
+# pin to an exact commit hash
+antidote bundle zsh-users/zsh-autosuggestions commit:abcd1234
 ----
 
 Using the *path:* annotation:

--- a/tests/functions/mockgit
+++ b/tests/functions/mockgit
@@ -13,11 +13,12 @@
   local args=("$@[@]")
   local o_path o_quiet o_ff o_rebase o_autostash o_short
   local o_depth o_recurse_submodules o_shallow_submodules o_branch
-  local o_init o_recursive
+  local o_init o_recursive o_detach
   zparseopts -D -E --      \
     C:=o_path              \
     -short=o_short         \
     -quiet=o_quiet         \
+    -detach=o_detach       \
     -ff=o_ff               \
     -rebase=o_rebase       \
     -autostash=o_autostash \
@@ -29,6 +30,9 @@
     -recursive=o_recursive                  ||
     return 1
 
+  local bundledir
+  (( $#o_path )) && bundledir=${o_path[-1]}
+
   if [[ "$@" = "--version" ]]; then
     echo "mockgit version 0.0.0"
   elif [[ "$1" = "clone" ]]; then
@@ -39,6 +43,7 @@
     if [[ -d "$gitsite_repodir" ]]; then
       [[ -d "${bundledir:A}" ]] || mkdir -p "${bundledir:A}"
       cp -r -- "$gitsite_repodir" "${bundledir:A}"
+      echo "abcd1230abcd1230abcd1230abcd1230abcd1230" > "${bundledir:A}/.git/HEAD_COMMIT"
     elif ! (( $#o_quiet )); then
       echo "MOCKGIT: Cloning into '${repo:t}'..."
       echo "MOCKGIT: Repository not found."
@@ -58,11 +63,20 @@
     fi
   elif [[ "$@" = "pull" ]]; then
     (( $#o_quiet )) || echo "MOCKGIT: Already up to date."
+  elif [[ "$1" = "checkout" ]]; then
+    local commit="${@: -1}"
+    [[ -z "$bundledir" ]] || echo "$commit" > "${bundledir:A}/.git/HEAD_COMMIT"
   elif [[ "$@" = "rev-parse HEAD" ]]; then
-    if (( $#o_short )); then
-      echo "abcd123"
+    local mock_head_commit
+    if [[ -n "$bundledir" ]] && [[ -r "${bundledir:A}/.git/HEAD_COMMIT" ]]; then
+      mock_head_commit="$(<"${bundledir:A}/.git/HEAD_COMMIT")"
     else
-      echo "abcd1230abcd1230abcd1230abcd1230abcd1230"
+      mock_head_commit="abcd1230abcd1230abcd1230abcd1230abcd1230"
+    fi
+    if (( $#o_short )); then
+      echo "${mock_head_commit:0:7}"
+    else
+      echo "$mock_head_commit"
     fi
   elif [[ "$1" == (submodule|fetch) ]]; then
     # nothing to do

--- a/tests/test_bundle_helpers.md
+++ b/tests/test_bundle_helpers.md
@@ -50,6 +50,8 @@ antidote-script foo/bar
 ```zsh
 % echo 'https://github.com/foo/bar path:lib branch:dev' | __antidote_parse_bundles
 antidote-script --branch dev --path lib https://github.com/foo/bar
+% echo 'https://github.com/foo/bar path:lib branch:dev commit:abcd1234' | __antidote_parse_bundles
+antidote-script --branch dev --commit abcd1234 --path lib https://github.com/foo/bar
 % echo 'git@github.com:foo/bar.git kind:clone branch:main' | __antidote_parse_bundles
 antidote-script --branch main --kind clone git@github.com:foo/bar.git
 % echo 'foo/bar kind:fpath abc:xyz' | __antidote_parse_bundles

--- a/tests/test_cmd_script.md
+++ b/tests/test_cmd_script.md
@@ -95,6 +95,15 @@ Clone a missing plugin.
 %
 ```
 
+### commit:hash
+
+```zsh
+% antidote-script --commit abcd1230abcd1230abcd1230abcd1230abcd1230 foo/bar | subenv ANTIDOTE_HOME
+fpath+=( "$ANTIDOTE_HOME/foo/bar" )
+source "$ANTIDOTE_HOME/foo/bar/bar.plugin.zsh"
+%
+```
+
 ### kind:zsh
 
 ```zsh


### PR DESCRIPTION
_This feature and PR description were generated with the assistance of an LLM (GitHub Copilot / Claude Sonnet 4.6). The implementation was reviewed and the commit message was adjusted by the author prior to merging._

Closes #1 

## Summary

Adds a new `commit:<hash>` annotation to the `.zsh_plugins.txt` DSL, allowing users to pin a plugin to an exact git commit hash.

## Motivation

The existing `branch:` annotation tracks the tip of a branch, which can change over time. For reproducible environments or security-sensitive setups, users need the ability to lock a plugin to a verified, immutable revision.

## Usage

```zsh
# .zsh_plugins.txt

# pin to a specific commit
zsh-users/zsh-autosuggestions commit:abc1234

# combine with other annotations
ohmyzsh/ohmyzsh path:plugins/git commit:abc1234 kind:fpath
```

## Notes

- If `branch:` and `commit:` are both provided, `commit:` wins — the repo ends up in detached HEAD at the specified hash.
- `antidote update` does not currently re-apply commit pins during the pull step. Pinned repos in detached HEAD state will typically be left unchanged by `git pull`, and the pin is re-applied on the next `antidote load`.